### PR TITLE
Debian 8 support

### DIFF
--- a/library/firewall.py
+++ b/library/firewall.py
@@ -94,8 +94,10 @@ def main():
     cmd = None
     if facts['distribution'] in ['CentOS', 'RedHat']:
         cmd = "service iptables save"
-    elif facts['distribution'] == 'Debian':
+    elif facts['distribution'] == 'Debian' and facts['distribution_major_version'] <= 7:
         cmd = "service iptables-persistent save"
+    elif facts['distribution'] == 'Debian' and facts['distribution_major_version'] >= 8:
+        cmd = "service netfilter-persistent save"
 
     if cmd:
         _, stdout, stderr = module.run_command(cmd, check_rc=True)


### PR DESCRIPTION
> Warning: Firewall[997 reject unmatched tcp](provider=iptables): Unable to persist firewall rules: Execution of '/usr/sbin/service iptables-persistent save' returned 1: iptables-persistent: unrecognized service
> 
> This is because iptables-persistent changed to be a module of netfilter-persistent with the 1.0 release, and the init script changed accordingly. The correct command is now service netfilter-persistent save.

https://tickets.puppetlabs.com/browse/MODULES-1289
