### PR TITLE
Add a flag to disable firewall

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+firewall_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 - include: centos.yml
-  when: firewall_enabled and ansible_distribution == 'CentOS'
+  when: firewall_enabled|bool and ansible_distribution == 'CentOS'
 
 - include: debian.yml
-  when: firewall_enabled and ansible_distribution == 'Debian'
+  when: firewall_enabled|bool and ansible_distribution == 'Debian'
 
 - name: "Ensure the iptables.d directory exists"
   file: >
@@ -11,7 +11,7 @@
     mode=0700
     owner=root
     group=root
-  when: firewall_enabled
+  when: firewall_enabled|bool
   tags:
     - firewall
 
@@ -23,7 +23,7 @@
     backup=no
     owner=root
     group=root
-  when: firewall_enabled
+  when: firewall_enabled|bool
   register: firewall_rule
   tags:
     - firewall
@@ -32,6 +32,6 @@
 - name: "Reload the firewall"
   firewall: >
     state=reloaded
-  when: firewall_enabled and firewall_rule|changed
+  when: firewall_enabled|bool and firewall_rule|changed
   tags:
     - firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 - include: centos.yml
-  when: ansible_distribution == 'CentOS'
+  when: firewall_enabled and ansible_distribution == 'CentOS'
 
 - include: debian.yml
-  when: ansible_distribution == 'Debian'
+  when: firewall_enabled and ansible_distribution == 'Debian'
 
 - name: "Ensure the iptables.d directory exists"
   file: >
@@ -11,6 +11,7 @@
     mode=0700
     owner=root
     group=root
+  when: firewall_enabled
   tags:
     - firewall
 
@@ -22,6 +23,7 @@
     backup=no
     owner=root
     group=root
+  when: firewall_enabled
   register: firewall_rule
   tags:
     - firewall
@@ -30,6 +32,6 @@
 - name: "Reload the firewall"
   firewall: >
     state=reloaded
-  when: firewall_rule|changed
+  when: firewall_enabled and firewall_rule|changed
   tags:
     - firewall


### PR DESCRIPTION
Firewall can now be enabled/disabled for some of your hosts by setting `firewall_enabled: true/false`
